### PR TITLE
Do not `force` cli to refresh the display

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Version (development version)
 
+* `handler_cli()` no longer forces a display update after every
+  tick, instead relying on cli itself to decide how often to
+  refresh the display. This results in much better performance.
+
+
 ## Deprecated and Defunct
 
  * Remove `progress()`, which has been defunct since **progressr**

--- a/R/handler_cli.R
+++ b/R/handler_cli.R
@@ -84,10 +84,10 @@ handler_cli <- function(show_after = 0.0, intrusiveness = getOption("progressr.i
       cli_progress_call(cli::cli_progress_bar, total = total, ...)
     }
 
-    cli_progress_update <- function(id, ..., force = TRUE, .envir) {
+    cli_progress_update <- function(id, ..., .envir) {
       ## WORKAROUND: Do not involve 'cli' when total = 0
       if (.envir$total == 0) return(id)
-      cli_progress_call(cli::cli_progress_update, id = id, ..., force = force, .envir = .envir)
+      cli_progress_call(cli::cli_progress_update, id = id, ..., .envir = .envir)
     }
 
     cli_progress_done <- function(id, ..., .envir) {
@@ -116,7 +116,7 @@ handler_cli <- function(show_after = 0.0, intrusiveness = getOption("progressr.i
     }
   } else {
     cli_progress_bar <- function(total, ...) "id-dummy"
-    cli_progress_update <- function(id, ..., force = TRUE, .envir) "id-dummy"
+    cli_progress_update <- function(id, ..., .envir) "id-dummy"
     cli_progress_done <- function(id, ..., .envir) "id-dummy"
     erase_progress_bar <- function(pb) NULL
     redraw_progress_bar <- function(pb) NULL


### PR DESCRIPTION
Closes #167

Instead, rely on cli's own internal timing and trust that it knows when to refresh the display at regular intervals.

`force`ing a refresh results in WAY slower progress bars, because it forces cli to do a whole bunch of work at each iteration. In particular, it calls `cli:::inline_transformer()` via `cli:::glue()` WAY more often, which is what does the inline interpolation in cli. As shown in https://github.com/futureverse/progressr/issues/167#issuecomment-3806012385, this takes a huge amount of time.

Running the original example from #167 

```r
f <- function(R = 1000) {
  pb <- progressr::progressor(steps = R)
  onerun <- function(...) {
    pb()
    Sys.sleep(0.001)
  }
  system.time(lapply(seq_len(R), onerun))
}

progressr::handlers(global = TRUE)

progressr::handlers(progressr::handler_void)
f() |> print()
#>   user  system elapsed 
#>  0.155   0.011   1.427 

progressr::handlers(progressr::handler_progress)
f() |> print()
#>   user  system elapsed 
#>  0.401   0.019   1.672 

progressr::handlers(progressr::handler_cli)
f() |> print()
#>   user  system elapsed 
#>  0.234   0.010   1.498 
```

Cranked up to 10k iterations

```r
f <- function(R = 10000) {
  pb <- progressr::progressor(steps = R)
  onerun <- function(...) {
    pb()
    Sys.sleep(0.001)
  }
  system.time(lapply(seq_len(R), onerun))
}

progressr::handlers(global = TRUE)

progressr::handlers(progressr::handler_void)
f() |> print()
#>   user  system elapsed 
#>  2.017   0.138  14.910 

progressr::handlers(progressr::handler_progress)
f() |> print()
#>   user  system elapsed 
#>  4.663   0.424  17.605 

progressr::handlers(progressr::handler_cli)
f() |> print()
#>   user  system elapsed 
#>  3.081   0.383  16.065 
```